### PR TITLE
Support html-webpack-plugin scriptLoading: "module"

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -60,6 +60,9 @@ export class WebpackNoModulePlugin {
                 const nomodule = this._config.filePatterns.some(pattern => minimatch(s.attributes.src, pattern));
                 if (nomodule) {
                     s.attributes.nomodule = true;
+                    if (s.attributes.type === 'module') {
+                        delete s.attributes.type;
+                    }
                 }
             }
             return s;


### PR DESCRIPTION
Remove `type` attribute if set to `module`. (html-webpack-plugin sets `type='module'` for all scripts if `scriptLoading` is set to `'module'`)

`nomodule `is ignored by browser if both  `nomodule` and `type="module"` are set.

![image](https://user-images.githubusercontent.com/10961167/209310688-e6192844-b4f1-4095-ad6f-f58f366180e1.png)


fixes #10 